### PR TITLE
feat(metadata): Add default Open Graph image

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,24 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.ico",
   },
+  openGraph: {
+    title: "Gitchegumi Media",
+    description: "The web presence for Gitchegumi!",
+    url: "https://dev.gitchegumi.com",
+    siteName: "Gitchegumi Media",
+    images: [
+      {
+        url: "https://dev.gitchegumi.com/images/Mascot.png", // Must be an absolute URL
+      },
+    ],
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Gitchegumi Media",
+    description: "The web presence for Gitchegumi!",
+    images: ["https://dev.gitchegumi.com/images/Mascot.png"], // Must be an absolute URL
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
This change introduces a site-wide feature image by adding Open Graph (og:image) and Twitter (twitter:image) metadata to the root layout. It uses Mascot.png as the default image that will appear when any link from the site is shared on social media platforms.

This approach ensures brand consistency without needing to specify an image for every individual page, resolving the core requirement of the issue.

Closes #15