### PR TITLE
feat: integrate hosted Cusdis comments on blog posts

### DIFF
--- a/src/app/blog/[category]/[slug]/page.tsx
+++ b/src/app/blog/[category]/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { getAllPosts } from "@/lib/getAllPosts";
 import ProseLayout from "@/components/ProseLayout";
 import type { PostMeta } from "@/lib/types";
+import Script from "next/script";
 
 type Props = {
   params: Promise<{
@@ -20,7 +21,7 @@ export async function generateMetadata({ params }: Props) {
   }
 
   return {
-    title: `Gitchegumi Media | Blog | ${post.title}`,
+    title: `${post.title} | Blog | Gitchegumi Media`,
   };
 }
 
@@ -40,6 +41,7 @@ export default async function BlogPostPage({ params }: Props) {
 
   return (
     <>
+      {/* JSON-LD structured data for SEO */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -58,7 +60,27 @@ export default async function BlogPostPage({ params }: Props) {
         }}
       />
       <ProseLayout title={metadata.title}>
-        <Post />
+        <article>
+          
+          {/* Post content */}
+          <Post />
+        </article>
+        <hr className="border-muted"/>
+        <div className="max-w-5xl mx-auto text-center px-4">
+          <p className="text-xl md:text-2xl font-bold">Feel like joining the conversation?<br/>Leave your comments below!</p>
+          {/* Cusdis comment thread */}
+          <div
+            id="cusdis_thread"
+            data-host="https://cusdis.com"
+            data-app-id="ebb02184-7fe1-429c-abd2-bc34ed96dd6c"
+            data-page-id={slug}
+            data-page-url={`https://yourdomain.com/blog/${category}/${slug}`}
+            data-page-title={metadata.title}
+            className="mt-16 bg-brand-blue/50 rounded-lg ring-brand-orange ring"
+          />
+
+          <Script src="https://cusdis.com/js/cusdis.es.js" strategy="lazyOnload" />
+        </div>
       </ProseLayout>
     </>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,4 +140,10 @@
     outline: none !important;
     box-shadow: none !important;
   }
+  #cusdis_thread iframe {
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+    color: #f0f0f0 !important;
+  }
 }


### PR DESCRIPTION
closes #13 

adds support for user comments via the hosted [Cusdis](https://cusdis.com) comment platform.

### ✨ Features:

* Dynamically embeds a Cusdis thread per blog post using `slug`, `category`, and `title`
* Adds a styled call-to-action prompting users to join the conversation
* Applies custom Tailwind layout to center and visually distinguish the comment section
* Loads the Cusdis script via `next/script` using `lazyOnload` for performance

### 🔐 Notes:

* Comments from anonymous users are pre-moderated using the Cusdis dashboard
* The public `data-app-id` is embedded as required (non-sensitive)
* Styling is intentionally minimal and can be refined or replaced with a self-hosted solution (e.g., Isso) in a future iteration