### PR TITLE
fix: resolve axios NO_PROXY bypass (CVE-2025-62718)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2691,15 +2691,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/bail": {
@@ -6404,11 +6404,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "typescript": "5.9.3"
   },
   "overrides": {
-    "minimatch": "^10.2.5"
+    "minimatch": "^10.2.5",
+    "axios": ">=1.15.0"
   }
 }


### PR DESCRIPTION
## Summary

Patches CVE-2025-62718 (GHSA-3p68-rc4w-qgx5, medium severity): Axios does not correctly handle hostname normalization when checking NO_PROXY rules. Requests to loopback addresses like `localhost.` (trailing dot) or `[::1]` skip NO_PROXY matching and go through the configured proxy, enabling SSRF attacks.

**Root cause:** Axios performed literal string comparison instead of normalizing hostnames before NO_PROXY evaluation (trailing dots not stripped, IPv6 brackets not removed).

**Fix:** Axios v1.15.0 includes the fix (PR axios/axios#10661). This PR adds an `overrides` entry in `package.json` to force `axios >= 1.15.0`, overriding the transitive `axios@1.13.6` currently pulled in by `@tryghost/content-api`.

## Changes

- `package.json`: Added `axios: ">=1.15.0"` to `overrides`
- `package-lock.json`: Re-resolved with override → `axios@1.15.2`

## Testing

`npm ls axios` confirms `axios@1.15.2` is resolved (overridden from `@tryghost/content-api`'s `1.13.6`).
