### PR TITLE
security: bump @next/mdx 15.3.5 → 16.2.6 (CVE-2026-44580 / GHSA-gx5p-jg67-6x7h)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
-        "@next/mdx": "^15.3.5",
+        "@next/mdx": "^16.2.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.7",
@@ -1103,9 +1103,9 @@
       "license": "MIT"
     },
     "node_modules/@next/mdx": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.3.5.tgz",
-      "integrity": "sha512-/2rRCgPKNp2ttQscU13auI+cYYACdPa80Okgi/1+NNJJeWn9yVxwGnqZc3SX30T889bZbLqcY4oUjqYGAygL4g==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.2.6.tgz",
+      "integrity": "sha512-0hdoSkzRbyud1dNRRDiyqD9FrxR2wwdiW+ffhYx+n+fXrFOJ7Nwpi8o7nUz2LiiM44BB9M0eIO1Evy3BBrS50A==",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.7.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
-    "@next/mdx": "^15.3.5",
+    "@next/mdx": "^16.2.6",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.7",


### PR DESCRIPTION
## Summary

Bumps `@next/mdx` from 15.3.5 to 16.2.6 to address **CVE-2026-44580** (GHSA-gx5p-jg67-6x7h).

### Details
- **Severity:** Medium
- **Issue:** Cross-site scripting in `beforeInteractive` scripts with untrusted input
- **Fix version:** `next` \u003e= 16.2.6 (patched)
- **Current state:** `next` was already bumped to ^16.2.6 in PR #168; this PR aligns the `@next/mdx` peer dependency to the same version.

### Changes
- `@next/mdx`: ^15.3.5 → ^16.2.6
- `package-lock.json`: regenerated with updated @next/mdx@16.2.6

### Verification
- `npm install` completed with 0 vulnerabilities
- All existing CI checks expected to pass