### PR TITLE
security: fix CVE-2026-45149 in brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2803,9 +2803,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

Bumps `brace-expansion` from 5.0.5 to 5.0.6 to fix [CVE-2026-45149](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) / [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2).

## Vulnerability

- **Package:** npm:brace-expansion
- **Severity:** Moderate
- **Affected:** \u003e\= 5.0.0, \u003c 5.0.6
- **Issue:** Large numeric range defeats documented `max` DoS protection, causing uncontrolled resource consumption (CWE-400)

## Changes

- Updated `package-lock.json` to resolve brace-expansion to patched version 5.0.6

---
_This PR was generated automatically in response to a Dependabot security alert._