### PR TITLE
fix: resolve CVE-2026-41907 in npm:uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7395,12 +7395,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "overrides": {
     "minimatch": "^10.2.5",
     "axios": ">=1.15.0",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
Adds npm override to force uuid ^11.1.1, resolving GHSA-w5hq-g745-h8pq.

The vulnerable version was a transitive dependency of exceljs@4.4.0 which pins uuid@^8.3.0. Override ensures patched version is installed without downgrading exceljs or introducing breaking changes.

- CVE-2026-41907
- GHSA-w5hq-g745-h8pq