### PR TITLE
fix: bump brace-expansion to 5.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,9 +2191,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary
- Bumps transitive npm package `brace-expansion` from 5.0.6 to 5.0.7 in `package-lock.json`
- Resolves Dependabot alert GHSA-3jxr-9vmj-r5cp / CVE-2026-13149

## Verification
- `npm ls brace-expansion --all`
- `npm audit --package-lock-only --omit=dev`
- `npm audit --package-lock-only` (brace-expansion resolved; unrelated existing axios/js-yaml/tar advisories remain)
- `npm run lint` (fails: existing script invokes `next lint`, which Next treats as invalid project directory `lint`)
- `npm run build`
