### PR TITLE
Fix axios NO_PROXY bypass advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,9 +2078,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "overrides": {
     "minimatch": "^10.2.5",
-    "axios": ">=1.17.0",
+    "axios": "1.18.1",
     "postcss": "^8.5.10",
     "uuid": "^11.1.1",
     "form-data": "^4.0.6",


### PR DESCRIPTION
## Summary
- pin the axios override to patched version 1.18.1
- refresh package-lock.json so transitive axios resolves to 1.18.1

## Verification
- npm install
- npm audit --package-lock-only (no axios vulnerability reported; existing unrelated vulnerabilities remain)
- npm run build

Fixes Dependabot alert #93 / GHSA-f4gw-2p7v-4548.