### PR TITLE
fix: bump axios for GHSA-gcfj-64vw-6mp9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,9 +2078,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "overrides": {
     "minimatch": "^10.2.5",
-    "axios": ">=1.17.0",
+    "axios": "1.18.1",
     "postcss": "^8.5.10",
     "uuid": "^11.1.1",
     "form-data": "^4.0.6",


### PR DESCRIPTION
## Summary
- Bump the axios override from >=1.17.0 to 1.18.1
- Refresh package-lock.json so @tryghost/content-api resolves axios 1.18.1

## Verification
- npm install
- npm ls axios --all
- npm audit --json confirms no axios vulnerability remains; 3 unrelated vulnerabilities remain
- npm run build passes
- npm run lint fails because the existing script invokes unsupported `next lint` and Next treats `lint` as a project directory

Dependabot alert: GHSA-gcfj-64vw-6mp9