### PR TITLE
fix: bump DOMPurify for GHSA-c2j3-45gr-mqc4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "exceljs": "^4.1.1",
         "fs": "^0.0.1-security",
         "jspdf": ">=4.2.1",
@@ -2674,9 +2674,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "exceljs": "^4.1.1",
     "fs": "^0.0.1-security",
     "jspdf": ">=4.2.1",


### PR DESCRIPTION
## Summary
- Bump `dompurify` from 3.4.11 to 3.4.12 to resolve GHSA-c2j3-45gr-mqc4.
- Refresh `package-lock.json` for lockfile consistency.

## Verification
- `npm audit --json` confirmed no remaining `dompurify` vulnerability.
- `npm run build` completed successfully.
- `npm run lint` currently fails because `next lint` is treated as an invalid project directory under Next.js 16.2.6 (`.../GitchPage/lint`).

Note: `npm audit` still reports unrelated vulnerabilities outside DOMPurify.